### PR TITLE
Add house service-account API keys

### DIFF
--- a/modules/core/src/main/java/org/reciplease/model/ApiKey.java
+++ b/modules/core/src/main/java/org/reciplease/model/ApiKey.java
@@ -1,0 +1,24 @@
+package org.reciplease.model;
+
+import java.time.Instant;
+
+/**
+ * A long-lived service-account credential scoped to one house, for third-party clients (e.g. a
+ * Home Assistant integration) that can't do an interactive sign-in. Created by a house owner,
+ * who names it and picks the {@link HouseRole} it acts with — it is not tied to any individual
+ * user's own access, so revoking a user's house membership does not affect keys they created.
+ * {@code keyHash} is the SHA-256 digest of the raw secret — the raw value itself is never
+ * persisted, only returned once at creation. {@code keyPrefix} is a short, non-secret slice of
+ * the raw key used to look up the matching record without scanning every stored hash.
+ */
+public record ApiKey(
+        String id,
+        String houseId,
+        String name,
+        HouseRole role,
+        String createdByUserId,
+        String keyPrefix,
+        String keyHash,
+        Instant createdAt,
+        Instant lastUsedAt) implements Identifiable, HouseScoped {
+}

--- a/modules/core/src/main/java/org/reciplease/model/ApiKeyPrincipal.java
+++ b/modules/core/src/main/java/org/reciplease/model/ApiKeyPrincipal.java
@@ -1,0 +1,9 @@
+package org.reciplease.model;
+
+/**
+ * What a successfully authenticated API key resolves to: the house it acts for and the role it
+ * acts with. Unlike a user JWT, there is no separate membership lookup — the key itself carries
+ * its authorization.
+ */
+public record ApiKeyPrincipal(String apiKeyId, String houseId, HouseRole role) {
+}

--- a/modules/core/src/main/java/org/reciplease/model/CreatedApiKey.java
+++ b/modules/core/src/main/java/org/reciplease/model/CreatedApiKey.java
@@ -1,0 +1,8 @@
+package org.reciplease.model;
+
+/**
+ * The result of minting a new {@link ApiKey}: the persisted record plus the one-time raw
+ * secret, which is never stored and cannot be recovered once this response is sent.
+ */
+public record CreatedApiKey(ApiKey apiKey, String rawKey) {
+}

--- a/modules/core/src/main/java/org/reciplease/repository/ApiKeyRepository.java
+++ b/modules/core/src/main/java/org/reciplease/repository/ApiKeyRepository.java
@@ -1,0 +1,23 @@
+package org.reciplease.repository;
+
+import org.reciplease.model.ApiKey;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface ApiKeyRepository {
+
+    /** Persists a brand-new API key. */
+    ApiKey create(ApiKey apiKey);
+
+    List<ApiKey> findAllForHouse(String houseId);
+
+    Optional<ApiKey> findByPrefix(String keyPrefix);
+
+    void updateLastUsedAt(String id, Instant lastUsedAt);
+
+    Optional<ApiKey> findById(String id);
+
+    void delete(String id);
+}

--- a/modules/core/src/main/java/org/reciplease/service/ApiKeyGenerator.java
+++ b/modules/core/src/main/java/org/reciplease/service/ApiKeyGenerator.java
@@ -1,0 +1,26 @@
+package org.reciplease.service;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * Generates raw API key secrets. The {@code rcpl_} prefix distinguishes them from Reciplease's
+ * session JWTs at a glance, which lets callers route an incoming bearer token to the right
+ * authentication path without first trying to parse it as a JWT.
+ */
+@Component
+public class ApiKeyGenerator {
+
+    public static final String PREFIX = "rcpl_";
+    private static final int SECRET_BYTES = 30;
+
+    private final SecureRandom random = new SecureRandom();
+
+    public String generate() {
+        final var bytes = new byte[SECRET_BYTES];
+        random.nextBytes(bytes);
+        return PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/modules/core/src/main/java/org/reciplease/service/ApiKeyHasher.java
+++ b/modules/core/src/main/java/org/reciplease/service/ApiKeyHasher.java
@@ -1,0 +1,22 @@
+package org.reciplease.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/** Hashes raw API key secrets for storage; SHA-256 is enough here since keys are high-entropy random values, not passwords. */
+final class ApiKeyHasher {
+
+    private ApiKeyHasher() {
+    }
+
+    static String hash(final String rawKey) {
+        try {
+            final var digest = MessageDigest.getInstance("SHA-256").digest(rawKey.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (final NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/modules/core/src/main/java/org/reciplease/service/ApiKeyService.java
+++ b/modules/core/src/main/java/org/reciplease/service/ApiKeyService.java
@@ -1,0 +1,81 @@
+package org.reciplease.service;
+
+import lombok.RequiredArgsConstructor;
+import org.reciplease.model.ApiKey;
+import org.reciplease.model.ApiKeyPrincipal;
+import org.reciplease.model.CreatedApiKey;
+import org.reciplease.model.HouseRole;
+import org.reciplease.repository.ApiKeyRepository;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ApiKeyService {
+
+    private static final int PREFIX_LENGTH = 15;
+
+    private final ApiKeyRepository apiKeyRepository;
+    private final ApiKeyGenerator apiKeyGenerator;
+
+    /**
+     * Mints and persists a new house-scoped service-account key. The raw secret is only ever
+     * available on the returned {@link CreatedApiKey} — only its hash is stored.
+     */
+    public CreatedApiKey create(final String houseId, final String name, final HouseRole role, final String createdByUserId) {
+        final var rawKey = apiKeyGenerator.generate();
+        final var apiKey = new ApiKey(
+                null, houseId, name, role, createdByUserId, prefixOf(rawKey), ApiKeyHasher.hash(rawKey), Instant.now(), null);
+        return new CreatedApiKey(apiKeyRepository.create(apiKey), rawKey);
+    }
+
+    public List<ApiKey> list(final String houseId) {
+        return apiKeyRepository.findAllForHouse(houseId);
+    }
+
+    /**
+     * Deletes API key {@code id}, but only if it belongs to {@code houseId} — mirrors the
+     * house-scoped delete checks elsewhere so an owner of one house can't revoke another
+     * house's key by guessing its id. Returns false if the key doesn't exist or belongs to a
+     * different house.
+     */
+    public boolean revoke(final String houseId, final String id) {
+        final var belongsToHouse = apiKeyRepository.findById(id)
+                .filter(key -> key.houseId().equals(houseId))
+                .isPresent();
+        if (belongsToHouse) {
+            apiKeyRepository.delete(id);
+        }
+        return belongsToHouse;
+    }
+
+    /**
+     * Resolves a raw bearer token to the house/role it acts as, in constant time against the
+     * stored hash. Empty if the token is malformed, unknown, or its hash doesn't match.
+     */
+    public Optional<ApiKeyPrincipal> authenticate(final String rawKey) {
+        if (rawKey.length() < PREFIX_LENGTH) {
+            return Optional.empty();
+        }
+        final var candidateHash = ApiKeyHasher.hash(rawKey);
+        return apiKeyRepository.findByPrefix(prefixOf(rawKey))
+                .filter(key -> constantTimeEquals(key.keyHash(), candidateHash))
+                .map(key -> {
+                    apiKeyRepository.updateLastUsedAt(key.id(), Instant.now());
+                    return new ApiKeyPrincipal(key.id(), key.houseId(), key.role());
+                });
+    }
+
+    private static String prefixOf(final String rawKey) {
+        return rawKey.substring(0, PREFIX_LENGTH);
+    }
+
+    private static boolean constantTimeEquals(final String a, final String b) {
+        return MessageDigest.isEqual(a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/modules/core/src/test/java/org/reciplease/service/ApiKeyGeneratorTest.java
+++ b/modules/core/src/test/java/org/reciplease/service/ApiKeyGeneratorTest.java
@@ -1,0 +1,29 @@
+package org.reciplease.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesPattern;
+
+class ApiKeyGeneratorTest {
+
+    private final ApiKeyGenerator generator = new ApiKeyGenerator();
+
+    @Test
+    void generatesKeysWithTheRcplPrefix() {
+        IntStream.range(0, 50)
+                .mapToObj(i -> generator.generate())
+                .forEach(key -> assertThat(key, matchesPattern("rcpl_[A-Za-z0-9_-]{40}")));
+    }
+
+    @Test
+    void generatesDistinctKeys() {
+        var first = generator.generate();
+        var second = generator.generate();
+
+        assertThat(first.equals(second), is(false));
+    }
+}

--- a/modules/core/src/test/java/org/reciplease/service/ApiKeyServiceTest.java
+++ b/modules/core/src/test/java/org/reciplease/service/ApiKeyServiceTest.java
@@ -1,0 +1,146 @@
+package org.reciplease.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.reciplease.model.ApiKey;
+import org.reciplease.model.HouseRole;
+import org.reciplease.repository.ApiKeyRepository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings
+class ApiKeyServiceTest {
+
+    private static final String HOUSE_ID = "house-1";
+
+    @Mock
+    private ApiKeyRepository apiKeyRepository;
+    @Mock
+    private ApiKeyGenerator apiKeyGenerator;
+
+    private ApiKeyService apiKeyService;
+
+    @BeforeEach
+    void setUp() {
+        apiKeyService = new ApiKeyService(apiKeyRepository, apiKeyGenerator);
+    }
+
+    @Test
+    void createGeneratesAndPersistsAKeyReturningTheRawSecretOnlyOnce() {
+        when(apiKeyGenerator.generate()).thenReturn("rcpl_abcdefghij1234567890");
+        when(apiKeyRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var created = apiKeyService.create(HOUSE_ID, "Home Assistant", HouseRole.READ_ONLY, "owner-1");
+
+        assertThat(created.rawKey(), is("rcpl_abcdefghij1234567890"));
+        assertThat(created.apiKey().houseId(), is(HOUSE_ID));
+        assertThat(created.apiKey().name(), is("Home Assistant"));
+        assertThat(created.apiKey().role(), is(HouseRole.READ_ONLY));
+        assertThat(created.apiKey().createdByUserId(), is("owner-1"));
+        assertThat(created.apiKey().keyPrefix(), is("rcpl_abcdefghij"));
+        assertThat(created.apiKey().keyHash(), is(not(created.rawKey())));
+        assertThat(created.apiKey().keyHash(), is(ApiKeyHasher.hash(created.rawKey())));
+    }
+
+    @Test
+    void listReturnsAllKeysForTheHouse() {
+        var key = apiKey("key-1");
+        when(apiKeyRepository.findAllForHouse(HOUSE_ID)).thenReturn(List.of(key));
+
+        assertThat(apiKeyService.list(HOUSE_ID), contains(key));
+    }
+
+    @Test
+    void revokeDeletesAKeyBelongingToTheHouse() {
+        when(apiKeyRepository.findById("key-1")).thenReturn(Optional.of(apiKey("key-1")));
+
+        var revoked = apiKeyService.revoke(HOUSE_ID, "key-1");
+
+        assertThat(revoked, is(true));
+        verify(apiKeyRepository).delete("key-1");
+    }
+
+    @Test
+    void revokeRefusesToDeleteAnotherHousesKey() {
+        var key = new ApiKey("key-1", "other-house", "name", HouseRole.READ_ONLY, "owner-1", "prefix", "hash", Instant.now(), null);
+        when(apiKeyRepository.findById("key-1")).thenReturn(Optional.of(key));
+
+        var revoked = apiKeyService.revoke(HOUSE_ID, "key-1");
+
+        assertThat(revoked, is(false));
+        verify(apiKeyRepository, never()).delete(any());
+    }
+
+    @Test
+    void revokeReturnsFalseWhenTheKeyDoesNotExist() {
+        when(apiKeyRepository.findById("missing")).thenReturn(Optional.empty());
+
+        var revoked = apiKeyService.revoke(HOUSE_ID, "missing");
+
+        assertThat(revoked, is(false));
+        verify(apiKeyRepository, never()).delete(any());
+    }
+
+    @Test
+    void authenticateReturnsThePrincipalForAMatchingKeyAndRecordsLastUsedAt() {
+        var rawKey = "rcpl_abcdefghij1234567890";
+        var hash = ApiKeyHasher.hash(rawKey);
+        var key = new ApiKey("key-1", HOUSE_ID, "name", HouseRole.OWNER, "owner-1", "rcpl_abcdefghij", hash, Instant.now(), null);
+        when(apiKeyRepository.findByPrefix("rcpl_abcdefghij")).thenReturn(Optional.of(key));
+
+        var authenticated = apiKeyService.authenticate(rawKey);
+
+        assertThat(authenticated.isPresent(), is(true));
+        assertThat(authenticated.get().apiKeyId(), is("key-1"));
+        assertThat(authenticated.get().houseId(), is(HOUSE_ID));
+        assertThat(authenticated.get().role(), is(HouseRole.OWNER));
+        verify(apiKeyRepository).updateLastUsedAt(eq("key-1"), any());
+    }
+
+    @Test
+    void authenticateReturnsEmptyWhenTheHashDoesNotMatch() {
+        var key = new ApiKey("key-1", HOUSE_ID, "name", HouseRole.OWNER, "owner-1", "rcpl_abcdefghij",
+                ApiKeyHasher.hash("rcpl_someotherkey1234567"), Instant.now(), null);
+        when(apiKeyRepository.findByPrefix("rcpl_abcdefghij")).thenReturn(Optional.of(key));
+
+        var authenticated = apiKeyService.authenticate("rcpl_abcdefghij1234567890");
+
+        assertThat(authenticated, is(Optional.empty()));
+        verify(apiKeyRepository, never()).updateLastUsedAt(any(), any());
+    }
+
+    @Test
+    void authenticateReturnsEmptyWhenNoKeyHasThatPrefix() {
+        when(apiKeyRepository.findByPrefix("rcpl_abcdefghij")).thenReturn(Optional.empty());
+
+        var authenticated = apiKeyService.authenticate("rcpl_abcdefghij1234567890");
+
+        assertThat(authenticated, is(Optional.empty()));
+    }
+
+    @Test
+    void authenticateReturnsEmptyForATokenThatIsTooShortToContainAPrefix() {
+        var authenticated = apiKeyService.authenticate("rcpl_short");
+
+        assertThat(authenticated, is(Optional.empty()));
+        verify(apiKeyRepository, never()).findByPrefix(any());
+    }
+
+    private static ApiKey apiKey(final String id) {
+        return new ApiKey(id, HOUSE_ID, "name", HouseRole.READ_ONLY, "owner-1", "prefix", "hash", Instant.now(), null);
+    }
+}

--- a/modules/database/src/main/java/org/reciplease/model/ApiKeyDocument.java
+++ b/modules/database/src/main/java/org/reciplease/model/ApiKeyDocument.java
@@ -1,0 +1,52 @@
+package org.reciplease.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Document("api_keys")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiKeyDocument {
+
+    @Id
+    private String id;
+    private String houseId;
+    private String name;
+    private String role;
+    private String createdByUserId;
+    @Indexed(unique = true)
+    private String keyPrefix;
+    private String keyHash;
+    @CreatedDate
+    private Instant createdAt;
+    private Instant lastUsedAt;
+
+    public static ApiKeyDocument from(final ApiKey apiKey) {
+        return ApiKeyDocument.builder()
+                .id(apiKey.id())
+                .houseId(apiKey.houseId())
+                .name(apiKey.name())
+                .role(apiKey.role() != null ? apiKey.role().name() : null)
+                .createdByUserId(apiKey.createdByUserId())
+                .keyPrefix(apiKey.keyPrefix())
+                .keyHash(apiKey.keyHash())
+                .createdAt(apiKey.createdAt())
+                .lastUsedAt(apiKey.lastUsedAt())
+                .build();
+    }
+
+    public ApiKey toModel() {
+        return new ApiKey(id, houseId, name, role != null ? HouseRole.valueOf(role) : null,
+                createdByUserId, keyPrefix, keyHash, createdAt, lastUsedAt);
+    }
+}

--- a/modules/database/src/main/java/org/reciplease/repository/ApiKeyRepositoryImpl.java
+++ b/modules/database/src/main/java/org/reciplease/repository/ApiKeyRepositoryImpl.java
@@ -1,0 +1,59 @@
+package org.reciplease.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.reciplease.model.ApiKey;
+import org.reciplease.model.ApiKeyDocument;
+import org.reciplease.repository.mongo.ApiKeyMongoRepository;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.stream.Collectors.toList;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+
+@Repository
+@RequiredArgsConstructor
+public class ApiKeyRepositoryImpl implements ApiKeyRepository {
+
+    private final ApiKeyMongoRepository apiKeyMongoRepository;
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public ApiKey create(final ApiKey apiKey) {
+        return apiKeyMongoRepository.save(ApiKeyDocument.from(apiKey)).toModel();
+    }
+
+    @Override
+    public List<ApiKey> findAllForHouse(final String houseId) {
+        return apiKeyMongoRepository.findAllByHouseId(houseId).stream()
+                .map(ApiKeyDocument::toModel)
+                .collect(toList());
+    }
+
+    @Override
+    public Optional<ApiKey> findByPrefix(final String keyPrefix) {
+        return apiKeyMongoRepository.findByKeyPrefix(keyPrefix).map(ApiKeyDocument::toModel);
+    }
+
+    @Override
+    public void updateLastUsedAt(final String id, final Instant lastUsedAt) {
+        mongoTemplate.updateFirst(
+                query(where("_id").is(id)), new Update().set("lastUsedAt", lastUsedAt), ApiKeyDocument.class);
+    }
+
+    @Override
+    public Optional<ApiKey> findById(final String id) {
+        return apiKeyMongoRepository.findById(id).map(ApiKeyDocument::toModel);
+    }
+
+    @Override
+    public void delete(final String id) {
+        apiKeyMongoRepository.deleteById(id);
+    }
+}

--- a/modules/database/src/main/java/org/reciplease/repository/mongo/ApiKeyMongoRepository.java
+++ b/modules/database/src/main/java/org/reciplease/repository/mongo/ApiKeyMongoRepository.java
@@ -1,0 +1,13 @@
+package org.reciplease.repository.mongo;
+
+import org.reciplease.model.ApiKeyDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ApiKeyMongoRepository extends MongoRepository<ApiKeyDocument, String> {
+    List<ApiKeyDocument> findAllByHouseId(String houseId);
+
+    Optional<ApiKeyDocument> findByKeyPrefix(String keyPrefix);
+}

--- a/modules/database/src/test/java/org/reciplease/repository/ApiKeyRepositoryImplTest.java
+++ b/modules/database/src/test/java/org/reciplease/repository/ApiKeyRepositoryImplTest.java
@@ -1,0 +1,96 @@
+package org.reciplease.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reciplease.model.ApiKey;
+import org.reciplease.model.HouseRole;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.mongodb.test.autoconfigure.DataMongoTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@DataMongoTest
+@Import(ApiKeyRepositoryImpl.class)
+class ApiKeyRepositoryImplTest {
+
+    private static final String HOUSE_ID = "house-1";
+
+    @Autowired
+    private ApiKeyRepository apiKeyRepository;
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @BeforeEach
+    void cleanDatabase() {
+        mongoTemplate.getCollectionNames().forEach(mongoTemplate::dropCollection);
+    }
+
+    @Test
+    void createPersistsANewApiKey() {
+        var apiKey = new ApiKey(null, HOUSE_ID, "Home Assistant", HouseRole.READ_ONLY, "owner-1", "rcpl_abc", "hash1", Instant.now(), null);
+
+        var created = apiKeyRepository.create(apiKey);
+
+        assertThat(created.id(), is(notNullValue()));
+        assertThat(apiKeyRepository.findById(created.id()).orElseThrow().name(), is("Home Assistant"));
+    }
+
+    @Test
+    void findAllForHouseReturnsOnlyThatHousesKeys() {
+        apiKeyRepository.create(newKey(HOUSE_ID, "key1", "rcpl_a"));
+        apiKeyRepository.create(newKey(HOUSE_ID, "key2", "rcpl_b"));
+        apiKeyRepository.create(newKey("house-2", "key3", "rcpl_c"));
+
+        var keys = apiKeyRepository.findAllForHouse(HOUSE_ID);
+
+        assertThat(keys.stream().map(ApiKey::name).toList(), containsInAnyOrder("key1", "key2"));
+    }
+
+    @Test
+    void findByPrefixFindsTheMatchingKey() {
+        apiKeyRepository.create(newKey(HOUSE_ID, "key1", "rcpl_a"));
+
+        var found = apiKeyRepository.findByPrefix("rcpl_a");
+
+        assertThat(found.orElseThrow().name(), is("key1"));
+    }
+
+    @Test
+    void findByPrefixReturnsEmptyWhenNoKeyMatches() {
+        var found = apiKeyRepository.findByPrefix("rcpl_missing");
+
+        assertThat(found.isEmpty(), is(true));
+    }
+
+    @Test
+    void updateLastUsedAtSetsTheTimestamp() {
+        var created = apiKeyRepository.create(newKey(HOUSE_ID, "key1", "rcpl_a"));
+        var lastUsedAt = Instant.parse("2026-01-01T00:00:00Z");
+
+        apiKeyRepository.updateLastUsedAt(created.id(), lastUsedAt);
+
+        assertThat(apiKeyRepository.findById(created.id()).orElseThrow().lastUsedAt(), is(lastUsedAt));
+    }
+
+    @Test
+    void deleteRemovesTheKey() {
+        var created = apiKeyRepository.create(newKey(HOUSE_ID, "key1", "rcpl_a"));
+
+        apiKeyRepository.delete(created.id());
+
+        assertThat(apiKeyRepository.findById(created.id()).isEmpty(), is(true));
+        assertThat(apiKeyRepository.findAllForHouse(HOUSE_ID), empty());
+    }
+
+    private static ApiKey newKey(final String houseId, final String name, final String prefix) {
+        return new ApiKey(null, houseId, name, HouseRole.READ_ONLY, "owner-1", prefix, "hash", Instant.now(), null);
+    }
+}

--- a/modules/web/src/main/java/org/reciplease/configuration/ApiKeyAuthenticationFilter.java
+++ b/modules/web/src/main/java/org/reciplease/configuration/ApiKeyAuthenticationFilter.java
@@ -1,0 +1,51 @@
+package org.reciplease.configuration;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.reciplease.service.ApiKeyGenerator;
+import org.reciplease.service.ApiKeyService;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Authenticates requests bearing a house service-account API key (see {@link ApiKeyService}),
+ * recognised by its {@code rcpl_} prefix rather than the three-dot-separated shape of a JWT.
+ * Runs before {@code BearerTokenAuthenticationFilter} in {@link CloudWebSecurityConfig} so a
+ * successful match here short-circuits JWT decoding entirely; {@link CookieBearerTokenResolver}
+ * additionally refuses to hand an {@code rcpl_} token to the JWT resolver at all, so an invalid
+ * API key can't fall through and get misinterpreted as a malformed JWT.
+ */
+@RequiredArgsConstructor
+public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String HEADER_PREFIX = "Bearer ";
+
+    private final ApiKeyService apiKeyService;
+
+    @Override
+    protected void doFilterInternal(
+            final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain)
+            throws ServletException, IOException {
+        final var token = resolveToken(request);
+        if (token != null) {
+            apiKeyService.authenticate(token)
+                    .ifPresent(principal -> SecurityContextHolder.getContext()
+                            .setAuthentication(new ApiKeyAuthenticationToken(principal)));
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private static String resolveToken(final HttpServletRequest request) {
+        final var header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith(HEADER_PREFIX)) {
+            return null;
+        }
+        final var token = header.substring(HEADER_PREFIX.length());
+        return token.startsWith(ApiKeyGenerator.PREFIX) ? token : null;
+    }
+}

--- a/modules/web/src/main/java/org/reciplease/configuration/ApiKeyAuthenticationToken.java
+++ b/modules/web/src/main/java/org/reciplease/configuration/ApiKeyAuthenticationToken.java
@@ -1,0 +1,41 @@
+package org.reciplease.configuration;
+
+import org.reciplease.model.ApiKeyPrincipal;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+
+/**
+ * The authenticated identity for a request bearing a valid house service-account API key (see
+ * {@link ApiKeyAuthenticationFilter}). Always carries {@code ROLE_RECIPLEASE} — a key is only
+ * ever minted for a house that already exists, so unlike a user JWT there is no separate
+ * membership check to fail. {@link HouseAccess} reads {@link #getPrincipal()} directly rather
+ * than consulting {@code HouseRepository}, since the key's house/role assignment *is* the
+ * authorization, not a lookup key into one.
+ */
+public class ApiKeyAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final ApiKeyPrincipal principal;
+
+    public ApiKeyAuthenticationToken(final ApiKeyPrincipal principal) {
+        super(List.of(new SimpleGrantedAuthority("ROLE_RECIPLEASE")));
+        this.principal = principal;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public ApiKeyPrincipal getPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return "apikey:" + principal.apiKeyId();
+    }
+}

--- a/modules/web/src/main/java/org/reciplease/configuration/CloudWebSecurityConfig.java
+++ b/modules/web/src/main/java/org/reciplease/configuration/CloudWebSecurityConfig.java
@@ -1,6 +1,7 @@
 package org.reciplease.configuration;
 
 import lombok.RequiredArgsConstructor;
+import org.reciplease.service.ApiKeyService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +13,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
 import javax.crypto.spec.SecretKeySpec;
@@ -25,6 +27,9 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
  * that, the {@code Authorization} header (see {@link CookieBearerTokenResolver}); authorization
  * (and any other per-endpoint check) is enforced via {@code @PreAuthorize} on individual
  * controller methods rather than URL-matcher rules here.
+ * <p>
+ * {@link ApiKeyAuthenticationFilter} runs ahead of the JWT-based {@code oauth2ResourceServer}
+ * filter to authenticate house service-account API keys instead, which aren't JWTs at all.
  * <p>
  * Missing/invalid tokens still yield 401 (the resource server rejects malformed bearer
  * tokens before a request reaches a controller); a valid token whose user belongs to no house
@@ -49,6 +54,7 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 public class CloudWebSecurityConfig {
 
     private final MembershipJwtAuthenticationConverter membershipJwtAuthenticationConverter;
+    private final ApiKeyService apiKeyService;
 
     @Value("${reciplease.jwt.signing-secret}")
     private String signingSecret;
@@ -83,6 +89,7 @@ public class CloudWebSecurityConfig {
                         .jwt(jwt -> jwt
                                 .decoder(jwtDecoder())
                                 .jwtAuthenticationConverter(membershipJwtAuthenticationConverter)))
+                .addFilterBefore(new ApiKeyAuthenticationFilter(apiKeyService), BearerTokenAuthenticationFilter.class)
                 .csrf(csrf -> csrf.disable())
                 .cors(Customizer.withDefaults())
                 .headers(headers -> headers.frameOptions(frame -> frame.disable()))

--- a/modules/web/src/main/java/org/reciplease/configuration/CookieBearerTokenResolver.java
+++ b/modules/web/src/main/java/org/reciplease/configuration/CookieBearerTokenResolver.java
@@ -1,6 +1,7 @@
 package org.reciplease.configuration;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.reciplease.service.ApiKeyGenerator;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.web.util.WebUtils;
@@ -11,6 +12,11 @@ import org.springframework.web.util.WebUtils;
  * own generic API proxy can forward it verbatim without decoding/re-encoding it as a header on
  * every request). Falls back to the standard {@code Authorization: Bearer} header so any caller
  * still using that convention (e.g. a frontend deploy mid-rollout) keeps working unchanged.
+ * <p>
+ * Never resolves an {@code rcpl_}-prefixed API key: those aren't JWTs, and {@link
+ * ApiKeyAuthenticationFilter} — which runs earlier in the chain — is the only thing that should
+ * ever attempt to decode one. Returning it here would otherwise reach the JWT decoder and 401 an
+ * otherwise-valid key (or an already-authenticated request) as a malformed token.
  */
 public class CookieBearerTokenResolver implements BearerTokenResolver {
 
@@ -21,6 +27,7 @@ public class CookieBearerTokenResolver implements BearerTokenResolver {
     @Override
     public String resolve(final HttpServletRequest request) {
         final var cookie = WebUtils.getCookie(request, COOKIE_NAME);
-        return cookie != null ? cookie.getValue() : headerResolver.resolve(request);
+        final var token = cookie != null ? cookie.getValue() : headerResolver.resolve(request);
+        return token != null && token.startsWith(ApiKeyGenerator.PREFIX) ? null : token;
     }
 }

--- a/modules/web/src/main/java/org/reciplease/configuration/HouseAccess.java
+++ b/modules/web/src/main/java/org/reciplease/configuration/HouseAccess.java
@@ -73,7 +73,20 @@ public class HouseAccess {
         return houseIdHeader();
     }
 
+    /**
+     * An {@link ApiKeyAuthenticationToken} carries its own house/role assignment — that
+     * assignment <em>is</em> the authorization, not a lookup key into {@link HouseRepository} —
+     * so it's resolved directly rather than via {@link #currentUserId()}/{@code roleOf}. Still
+     * requires the request's house header to match the key's own house, mirroring the
+     * {@link #belongsToHeaderHouse} defense used elsewhere.
+     */
     private Optional<HouseRole> resolveRole() {
+        final var authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof ApiKeyAuthenticationToken apiKeyAuthentication) {
+            final var principal = apiKeyAuthentication.getPrincipal();
+            return principal.houseId().equals(houseIdHeader()) ? Optional.of(principal.role()) : Optional.empty();
+        }
+
         final var houseId = houseIdHeader();
         final var userId = currentUserId();
         if (houseId == null || userId == null) {

--- a/modules/web/src/main/java/org/reciplease/controller/ApiKeyController.java
+++ b/modules/web/src/main/java/org/reciplease/controller/ApiKeyController.java
@@ -1,0 +1,66 @@
+package org.reciplease.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.reciplease.configuration.HouseAccess;
+import org.reciplease.configuration.HouseOwner;
+import org.reciplease.dto.ApiKeyDto;
+import org.reciplease.dto.CreateApiKeyRequest;
+import org.reciplease.dto.CreatedApiKeyDto;
+import org.reciplease.service.ApiKeyService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Manages house service-account API keys — long-lived credentials a house owner mints for a
+ * third-party client that can't do an interactive sign-in (e.g. a Home Assistant integration).
+ * Owner-only: a service account acts with a role the owner picks, so minting one is itself a
+ * grant of access, same as creating an invite.
+ */
+@RestController
+@RequestMapping("api/houses/api-keys")
+@RequiredArgsConstructor
+@HouseOwner
+public class ApiKeyController {
+
+    private final ApiKeyService apiKeyService;
+    private final HouseAccess houseAccess;
+
+    @GetMapping
+    public ResponseEntity<List<ApiKeyDto>> findAll() {
+        final var keys = apiKeyService.list(houseAccess.requireHouseId()).stream()
+                .map(ApiKeyDto::from)
+                .collect(toList());
+        return ResponseEntity.ok(keys);
+    }
+
+    @PostMapping
+    public ResponseEntity<CreatedApiKeyDto> create(@Valid @RequestBody final CreateApiKeyRequest request) {
+        final var created = apiKeyService.create(
+                houseAccess.requireHouseId(), request.getName(), request.getRole(), currentUserId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(CreatedApiKeyDto.from(created));
+    }
+
+    @DeleteMapping("{id}")
+    public ResponseEntity<Void> revoke(@PathVariable final String id) {
+        final var revoked = apiKeyService.revoke(houseAccess.requireHouseId(), id);
+        return revoked ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+
+    private String currentUserId() {
+        final var authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication != null && authentication.isAuthenticated() ? authentication.getName() : null;
+    }
+}

--- a/modules/web/src/main/java/org/reciplease/controller/ApiKeyController.java
+++ b/modules/web/src/main/java/org/reciplease/controller/ApiKeyController.java
@@ -2,14 +2,18 @@ package org.reciplease.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.reciplease.configuration.ApiKeyAuthenticationToken;
 import org.reciplease.configuration.HouseAccess;
 import org.reciplease.configuration.HouseOwner;
 import org.reciplease.dto.ApiKeyDto;
+import org.reciplease.dto.ApiKeySelfDto;
 import org.reciplease.dto.CreateApiKeyRequest;
 import org.reciplease.dto.CreatedApiKeyDto;
+import org.reciplease.repository.HouseRepository;
 import org.reciplease.service.ApiKeyService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,13 +36,14 @@ import static java.util.stream.Collectors.toList;
 @RestController
 @RequestMapping("api/houses/api-keys")
 @RequiredArgsConstructor
-@HouseOwner
 public class ApiKeyController {
 
     private final ApiKeyService apiKeyService;
     private final HouseAccess houseAccess;
+    private final HouseRepository houseRepository;
 
     @GetMapping
+    @HouseOwner
     public ResponseEntity<List<ApiKeyDto>> findAll() {
         final var keys = apiKeyService.list(houseAccess.requireHouseId()).stream()
                 .map(ApiKeyDto::from)
@@ -47,6 +52,7 @@ public class ApiKeyController {
     }
 
     @PostMapping
+    @HouseOwner
     public ResponseEntity<CreatedApiKeyDto> create(@Valid @RequestBody final CreateApiKeyRequest request) {
         final var created = apiKeyService.create(
                 houseAccess.requireHouseId(), request.getName(), request.getRole(), currentUserId());
@@ -54,9 +60,35 @@ public class ApiKeyController {
     }
 
     @DeleteMapping("{id}")
+    @HouseOwner
     public ResponseEntity<Void> revoke(@PathVariable final String id) {
         final var revoked = apiKeyService.revoke(houseAccess.requireHouseId(), id);
         return revoked ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+
+    /**
+     * Lets an API-key-authenticated caller discover the house/role its own key resolves to,
+     * since the raw key is opaque and carries nothing a client can read directly — a service
+     * account needs this before it knows what to send as {@code X-RCPLS-House-Id} on any other
+     * house-scoped call. Not meaningful for a normal user JWT (a user isn't scoped to a single
+     * house), so it 403s outside an API-key authentication.
+     */
+    @GetMapping("self")
+    @PreAuthorize("hasRole('RECIPLEASE')")
+    public ResponseEntity<ApiKeySelfDto> self() {
+        final var authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (!(authentication instanceof ApiKeyAuthenticationToken apiKeyAuthentication)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        final var principal = apiKeyAuthentication.getPrincipal();
+        final var houseName = houseRepository.findById(principal.houseId())
+                .map(house -> house.name())
+                .orElse(null);
+        return ResponseEntity.ok(ApiKeySelfDto.builder()
+                .houseId(principal.houseId())
+                .houseName(houseName)
+                .role(principal.role())
+                .build());
     }
 
     private String currentUserId() {

--- a/modules/web/src/main/java/org/reciplease/dto/ApiKeyDto.java
+++ b/modules/web/src/main/java/org/reciplease/dto/ApiKeyDto.java
@@ -1,0 +1,35 @@
+package org.reciplease.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+import org.reciplease.model.ApiKey;
+import org.reciplease.model.HouseRole;
+
+import java.time.Instant;
+
+/** The owner-facing listing shape for an {@link ApiKey} — never carries the raw secret. */
+@Value
+@AllArgsConstructor
+@Builder
+@Schema(name = "ApiKey")
+public class ApiKeyDto {
+    String id;
+    String name;
+    HouseRole role;
+    String keyPrefix;
+    Instant createdAt;
+    Instant lastUsedAt;
+
+    public static ApiKeyDto from(final ApiKey apiKey) {
+        return ApiKeyDto.builder()
+                .id(apiKey.id())
+                .name(apiKey.name())
+                .role(apiKey.role())
+                .keyPrefix(apiKey.keyPrefix())
+                .createdAt(apiKey.createdAt())
+                .lastUsedAt(apiKey.lastUsedAt())
+                .build();
+    }
+}

--- a/modules/web/src/main/java/org/reciplease/dto/ApiKeySelfDto.java
+++ b/modules/web/src/main/java/org/reciplease/dto/ApiKeySelfDto.java
@@ -1,0 +1,23 @@
+package org.reciplease.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+import org.reciplease.model.HouseRole;
+
+/**
+ * What an API-key-authenticated caller can discover about itself: the raw key is opaque and
+ * carries no house id a client can read directly, so a service account has to ask the backend
+ * which house/role it resolves to before it can start sending {@code X-RCPLS-House-Id}
+ * on subsequent house-scoped calls.
+ */
+@Value
+@AllArgsConstructor
+@Builder
+@Schema(name = "ApiKeySelf")
+public class ApiKeySelfDto {
+    String houseId;
+    String houseName;
+    HouseRole role;
+}

--- a/modules/web/src/main/java/org/reciplease/dto/CreateApiKeyRequest.java
+++ b/modules/web/src/main/java/org/reciplease/dto/CreateApiKeyRequest.java
@@ -1,0 +1,14 @@
+package org.reciplease.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Value;
+import org.reciplease.model.HouseRole;
+
+@Value
+public class CreateApiKeyRequest {
+    @NotBlank
+    String name;
+    @NotNull
+    HouseRole role;
+}

--- a/modules/web/src/main/java/org/reciplease/dto/CreatedApiKeyDto.java
+++ b/modules/web/src/main/java/org/reciplease/dto/CreatedApiKeyDto.java
@@ -1,0 +1,33 @@
+package org.reciplease.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+import org.reciplease.model.CreatedApiKey;
+import org.reciplease.model.HouseRole;
+
+import java.time.Instant;
+
+/** Returned only once, immediately after creation — {@code rawKey} can never be recovered afterwards. */
+@Value
+@AllArgsConstructor
+@Builder
+@Schema(name = "CreatedApiKey")
+public class CreatedApiKeyDto {
+    String id;
+    String name;
+    HouseRole role;
+    String rawKey;
+    Instant createdAt;
+
+    public static CreatedApiKeyDto from(final CreatedApiKey created) {
+        return CreatedApiKeyDto.builder()
+                .id(created.apiKey().id())
+                .name(created.apiKey().name())
+                .role(created.apiKey().role())
+                .rawKey(created.rawKey())
+                .createdAt(created.apiKey().createdAt())
+                .build();
+    }
+}

--- a/modules/web/src/test/java/org/reciplease/OpenApiSpecExportTest.java
+++ b/modules/web/src/test/java/org/reciplease/OpenApiSpecExportTest.java
@@ -11,6 +11,7 @@ import org.reciplease.repository.InviteRepository;
 import org.reciplease.repository.UserIdentityRepository;
 import org.reciplease.repository.UserRepository;
 import org.reciplease.repository.WebAuthnChallengeLedger;
+import org.reciplease.service.ApiKeyService;
 import org.reciplease.service.FoodSearchService;
 import org.reciplease.service.GoogleHealthAdapter;
 import org.reciplease.service.InventoryService;
@@ -94,6 +95,8 @@ class OpenApiSpecExportTest {
     private GoogleHealthAdapter googleHealthAdapter;
     @MockitoBean
     private FoodSearchService foodSearchService;
+    @MockitoBean
+    private ApiKeyService apiKeyService;
 
     @Test
     void exportsTheLiveSpecToTargetOpenapiJson() throws Exception {

--- a/modules/web/src/test/java/org/reciplease/configuration/ApiKeyAuthenticationFilterTest.java
+++ b/modules/web/src/test/java/org/reciplease/configuration/ApiKeyAuthenticationFilterTest.java
@@ -1,0 +1,95 @@
+package org.reciplease.configuration;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.reciplease.model.ApiKeyPrincipal;
+import org.reciplease.model.HouseRole;
+import org.reciplease.service.ApiKeyService;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings
+class ApiKeyAuthenticationFilterTest {
+
+    @Mock
+    private ApiKeyService apiKeyService;
+    @Mock
+    private FilterChain filterChain;
+
+    private ApiKeyAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new ApiKeyAuthenticationFilter(apiKeyService);
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void authenticatesAValidApiKeyBearerToken() throws Exception {
+        var principal = new ApiKeyPrincipal("key-1", "house-1", HouseRole.OWNER);
+        when(apiKeyService.authenticate("rcpl_abc123")).thenReturn(Optional.of(principal));
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer rcpl_abc123");
+        var response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication, is(notNullValue()));
+        assertThat(authentication.getPrincipal(), is(principal));
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void leavesTheSecurityContextUntouchedForAnInvalidApiKey() throws Exception {
+        when(apiKeyService.authenticate("rcpl_bad")).thenReturn(Optional.empty());
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer rcpl_bad");
+
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication(), is(nullValue()));
+    }
+
+    @Test
+    void ignoresNonApiKeyBearerTokens() throws Exception {
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.some.jwt");
+
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication(), is(nullValue()));
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    void ignoresRequestsWithNoAuthorizationHeader() throws Exception {
+        filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication(), is(nullValue()));
+        verifyNoInteractions(apiKeyService);
+    }
+
+    private static org.hamcrest.Matcher<Object> not(final org.hamcrest.Matcher<Object> matcher) {
+        return org.hamcrest.Matchers.not(matcher);
+    }
+}

--- a/modules/web/src/test/java/org/reciplease/configuration/ApiKeyAuthenticationFilterTest.java
+++ b/modules/web/src/test/java/org/reciplease/configuration/ApiKeyAuthenticationFilterTest.java
@@ -89,7 +89,14 @@ class ApiKeyAuthenticationFilterTest {
         verifyNoInteractions(apiKeyService);
     }
 
-    private static org.hamcrest.Matcher<Object> not(final org.hamcrest.Matcher<Object> matcher) {
-        return org.hamcrest.Matchers.not(matcher);
+    @Test
+    void ignoresNonBearerAuthorizationHeaders() throws Exception {
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+
+        filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication(), is(nullValue()));
+        verifyNoInteractions(apiKeyService);
     }
 }

--- a/modules/web/src/test/java/org/reciplease/configuration/ApiKeyAuthenticationTokenTest.java
+++ b/modules/web/src/test/java/org/reciplease/configuration/ApiKeyAuthenticationTokenTest.java
@@ -1,0 +1,25 @@
+package org.reciplease.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.reciplease.model.ApiKeyPrincipal;
+import org.reciplease.model.HouseRole;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+class ApiKeyAuthenticationTokenTest {
+
+    @Test
+    void carriesTheApiKeyIdAsItsNameAndTheRoleGrantingAuthorityOnly() {
+        var principal = new ApiKeyPrincipal("key-1", "house-1", HouseRole.OWNER);
+        var token = new ApiKeyAuthenticationToken(principal);
+
+        assertThat(token.getName(), is("apikey:key-1"));
+        assertThat(token.getPrincipal(), is(principal));
+        assertThat(token.getCredentials(), is(nullValue()));
+        assertThat(token.isAuthenticated(), is(true));
+        assertThat(token.getAuthorities().stream().map(Object::toString).toList(), contains("ROLE_RECIPLEASE"));
+    }
+}

--- a/modules/web/src/test/java/org/reciplease/configuration/CloudWebSecurityConfigTest.java
+++ b/modules/web/src/test/java/org/reciplease/configuration/CloudWebSecurityConfigTest.java
@@ -4,6 +4,8 @@ import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.reciplease.controller.MeasureController;
+import org.reciplease.model.ApiKeyPrincipal;
+import org.reciplease.model.HouseRole;
 import org.reciplease.service.ApiKeyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -20,6 +22,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -80,6 +85,25 @@ class CloudWebSecurityConfigTest {
     void protectedEndpointAllowedWithRole() throws Exception {
         mockMvc.perform(post("/api/test").with(jwt().authorities(new SimpleGrantedAuthority("ROLE_RECIPLEASE"))))
                 .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("a valid rcpl_ API key bearer token authenticates through the real filter chain")
+    void apiKeyBearerTokenAuthenticatesThroughTheRealFilterChain() throws Exception {
+        when(apiKeyService.authenticate("rcpl_valid1234567890"))
+                .thenReturn(Optional.of(new ApiKeyPrincipal("key-1", "house-1", HouseRole.OWNER)));
+
+        mockMvc.perform(post("/api/test").header("Authorization", "Bearer rcpl_valid1234567890"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("an unrecognised rcpl_ API key is rejected rather than falling through to the JWT decoder")
+    void unknownApiKeyBearerTokenIsRejected() throws Exception {
+        when(apiKeyService.authenticate("rcpl_unknown")).thenReturn(Optional.empty());
+
+        mockMvc.perform(post("/api/test").header("Authorization", "Bearer rcpl_unknown"))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/modules/web/src/test/java/org/reciplease/configuration/CloudWebSecurityConfigTest.java
+++ b/modules/web/src/test/java/org/reciplease/configuration/CloudWebSecurityConfigTest.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.reciplease.controller.MeasureController;
+import org.reciplease.service.ApiKeyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -49,6 +50,9 @@ class CloudWebSecurityConfigTest {
 
     @MockitoBean
     private JwtDecoder jwtDecoder;
+
+    @MockitoBean
+    private ApiKeyService apiKeyService;
 
     @Test
     @DisplayName("permits unauthenticated GET access to public read endpoints")

--- a/modules/web/src/test/java/org/reciplease/configuration/CookieBearerTokenResolverTest.java
+++ b/modules/web/src/test/java/org/reciplease/configuration/CookieBearerTokenResolverTest.java
@@ -43,4 +43,20 @@ class CookieBearerTokenResolverTest {
 
         assertThat(resolver.resolve(request), nullValue());
     }
+
+    @Test
+    void returnsNullForAnApiKeyBearerHeaderRatherThanHandingItToTheJwtDecoder() {
+        final var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer rcpl_someapikey1234567890");
+
+        assertThat(resolver.resolve(request), nullValue());
+    }
+
+    @Test
+    void returnsNullForAnApiKeyInTheSessionCookieToo() {
+        final var request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("reciplease-session", "rcpl_someapikey1234567890"));
+
+        assertThat(resolver.resolve(request), nullValue());
+    }
 }

--- a/modules/web/src/test/java/org/reciplease/configuration/HouseAccessTest.java
+++ b/modules/web/src/test/java/org/reciplease/configuration/HouseAccessTest.java
@@ -1,0 +1,71 @@
+package org.reciplease.configuration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.reciplease.model.ApiKeyPrincipal;
+import org.reciplease.model.HouseRole;
+import org.reciplease.repository.HouseRepository;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@MockitoSettings
+class HouseAccessTest {
+
+    @Mock
+    private HouseRepository houseRepository;
+
+    private HouseAccess houseAccess;
+
+    @BeforeEach
+    void setUp() {
+        houseAccess = new HouseAccess(houseRepository);
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void isMemberIsTrueForAnApiKeyWhoseHouseMatchesTheRequestHeader() {
+        withHouseHeader("house-1");
+        SecurityContextHolder.getContext().setAuthentication(
+                new ApiKeyAuthenticationToken(new ApiKeyPrincipal("key-1", "house-1", HouseRole.READ_ONLY)));
+
+        assertThat(houseAccess.isMember(), is(true));
+        assertThat(houseAccess.isOwner(), is(false));
+    }
+
+    @Test
+    void isOwnerIsTrueForAnOwnerScopedApiKey() {
+        withHouseHeader("house-1");
+        SecurityContextHolder.getContext().setAuthentication(
+                new ApiKeyAuthenticationToken(new ApiKeyPrincipal("key-1", "house-1", HouseRole.OWNER)));
+
+        assertThat(houseAccess.isOwner(), is(true));
+    }
+
+    @Test
+    void isMemberIsFalseWhenTheApiKeysHouseDoesNotMatchTheRequestHeader() {
+        withHouseHeader("house-2");
+        SecurityContextHolder.getContext().setAuthentication(
+                new ApiKeyAuthenticationToken(new ApiKeyPrincipal("key-1", "house-1", HouseRole.OWNER)));
+
+        assertThat(houseAccess.isMember(), is(false));
+    }
+
+    private static void withHouseHeader(final String houseId) {
+        final var request = new MockHttpServletRequest();
+        request.addHeader(HouseAccess.HOUSE_HEADER, houseId);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    }
+}

--- a/modules/web/src/test/java/org/reciplease/configuration/HouseAccessTest.java
+++ b/modules/web/src/test/java/org/reciplease/configuration/HouseAccessTest.java
@@ -63,6 +63,15 @@ class HouseAccessTest {
         assertThat(houseAccess.isMember(), is(false));
     }
 
+    @Test
+    void isMemberIsFalseForAnApiKeyWhenTheRequestHasNoHouseHeaderAtAll() {
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
+        SecurityContextHolder.getContext().setAuthentication(
+                new ApiKeyAuthenticationToken(new ApiKeyPrincipal("key-1", "house-1", HouseRole.OWNER)));
+
+        assertThat(houseAccess.isMember(), is(false));
+    }
+
     private static void withHouseHeader(final String houseId) {
         final var request = new MockHttpServletRequest();
         request.addHeader(HouseAccess.HOUSE_HEADER, houseId);

--- a/modules/web/src/test/java/org/reciplease/controller/ApiKeyControllerSelfTest.java
+++ b/modules/web/src/test/java/org/reciplease/controller/ApiKeyControllerSelfTest.java
@@ -1,0 +1,71 @@
+package org.reciplease.controller;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.reciplease.configuration.ApiKeyAuthenticationToken;
+import org.reciplease.configuration.HouseAccess;
+import org.reciplease.model.ApiKeyPrincipal;
+import org.reciplease.model.House;
+import org.reciplease.model.HouseRole;
+import org.reciplease.repository.HouseRepository;
+import org.reciplease.service.ApiKeyService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+/**
+ * Exercises {@link ApiKeyController#self()} directly rather than through {@code @WebMvcTest} +
+ * {@code MockMvc}: the class's {@code @WithHouseOwner} default authentication (needed for the
+ * owner-only endpoints in {@link ApiKeyControllerTest}) takes precedence over a per-request
+ * {@code SecurityMockMvcRequestPostProcessors.authentication()} override there, so this method
+ * — the one endpoint that cares about the concrete authentication *type* rather than just a
+ * granted authority — is easier to verify by calling it directly against a controlled
+ * {@link SecurityContextHolder} instead.
+ */
+@MockitoSettings
+class ApiKeyControllerSelfTest {
+
+    @Mock
+    private ApiKeyService apiKeyService;
+    @Mock
+    private HouseAccess houseAccess;
+    @Mock
+    private HouseRepository houseRepository;
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void resolvesTheHouseAndRoleAnApiKeyAuthenticatesAs() {
+        when(houseRepository.findById("house-1")).thenReturn(Optional.of(new House("house-1", "Test House", Instant.now())));
+        SecurityContextHolder.getContext().setAuthentication(
+                new ApiKeyAuthenticationToken(new ApiKeyPrincipal("key-1", "house-1", HouseRole.READ_ONLY)));
+
+        var response = new ApiKeyController(apiKeyService, houseAccess, houseRepository).self();
+
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.getBody().getHouseId(), is("house-1"));
+        assertThat(response.getBody().getHouseName(), is("Test House"));
+        assertThat(response.getBody().getRole(), is(HouseRole.READ_ONLY));
+    }
+
+    @Test
+    void isForbiddenForANonApiKeyAuthentication() {
+        SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken("user-1", "n/a"));
+
+        var response = new ApiKeyController(apiKeyService, houseAccess, houseRepository).self();
+
+        assertThat(response.getStatusCode(), is(HttpStatus.FORBIDDEN));
+    }
+}

--- a/modules/web/src/test/java/org/reciplease/controller/ApiKeyControllerTest.java
+++ b/modules/web/src/test/java/org/reciplease/controller/ApiKeyControllerTest.java
@@ -1,0 +1,146 @@
+package org.reciplease.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.reciplease.configuration.HouseAccess;
+import org.reciplease.configuration.MethodSecurityTestSupport;
+import org.reciplease.configuration.WithHouseMember;
+import org.reciplease.configuration.WithHouseOwner;
+import org.reciplease.model.ApiKey;
+import org.reciplease.model.CreatedApiKey;
+import org.reciplease.model.HouseRole;
+import org.reciplease.service.ApiKeyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApiKeyController.class)
+@WithHouseOwner
+@Import(MethodSecurityTestSupport.class)
+class ApiKeyControllerTest {
+
+    private static final String HOUSE_ID = "house-1";
+
+    @MockitoBean
+    private ApiKeyService apiKeyService;
+    @MockitoBean(name = "houseAccess")
+    private HouseAccess houseAccess;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void stubHouseAccess() {
+        when(houseAccess.isOwner()).thenReturn(true);
+        when(houseAccess.isMember()).thenReturn(true);
+        when(houseAccess.requireHouseId()).thenReturn(HOUSE_ID);
+    }
+
+    @Test
+    @DisplayName("should list keys for the house without exposing the raw secret")
+    void findAll() throws Exception {
+        var createdAt = Instant.parse("2026-01-01T00:00:00Z");
+        when(apiKeyService.list(HOUSE_ID)).thenReturn(List.of(
+                new ApiKey("key-1", HOUSE_ID, "Home Assistant", HouseRole.READ_ONLY, "owner-1", "rcpl_abc", "hash", createdAt, null)));
+
+        mockMvc.perform(get("/api/houses/api-keys"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                        [
+                          {"id": "key-1", "name": "Home Assistant", "role": "READ_ONLY", "keyPrefix": "rcpl_abc", "createdAt": "2026-01-01T00:00:00Z"}
+                        ]""", true));
+    }
+
+    @Test
+    @DisplayName("findAll is forbidden for read-only members")
+    @WithHouseMember
+    void findAllForbiddenForReadOnly() throws Exception {
+        when(houseAccess.isOwner()).thenReturn(false);
+
+        mockMvc.perform(get("/api/houses/api-keys"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("should create a key and return the raw secret once")
+    @WithMockUser(username = "owner-1", authorities = "ROLE_RECIPLEASE")
+    void create() throws Exception {
+        var createdAt = Instant.parse("2026-01-01T00:00:00Z");
+        var apiKey = new ApiKey("key-1", HOUSE_ID, "Home Assistant", HouseRole.READ_ONLY, "owner-1", "rcpl_abc", "hash", createdAt, null);
+        when(apiKeyService.create(HOUSE_ID, "Home Assistant", HouseRole.READ_ONLY, "owner-1"))
+                .thenReturn(new CreatedApiKey(apiKey, "rcpl_abcdefghij1234567890"));
+
+        mockMvc.perform(post("/api/houses/api-keys")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name": "Home Assistant", "role": "READ_ONLY"}"""))
+                .andExpect(status().isCreated())
+                .andExpect(content().json("""
+                        {"id": "key-1", "name": "Home Assistant", "role": "READ_ONLY",
+                         "rawKey": "rcpl_abcdefghij1234567890", "createdAt": "2026-01-01T00:00:00Z"}""", true));
+    }
+
+    @Test
+    @DisplayName("create is forbidden for read-only members")
+    @WithHouseMember
+    void createForbiddenForReadOnly() throws Exception {
+        when(houseAccess.isOwner()).thenReturn(false);
+
+        mockMvc.perform(post("/api/houses/api-keys")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name": "Home Assistant", "role": "READ_ONLY"}"""))
+                .andExpect(status().isForbidden());
+
+        verify(apiKeyService, never()).create(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("should revoke a key")
+    void revoke() throws Exception {
+        when(apiKeyService.revoke(HOUSE_ID, "key-1")).thenReturn(true);
+
+        mockMvc.perform(delete("/api/houses/api-keys/{id}", "key-1").with(csrf()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("should 404 when revoking an unknown or mismatched key")
+    void revokeNotFound() throws Exception {
+        when(apiKeyService.revoke(HOUSE_ID, "key-1")).thenReturn(false);
+
+        mockMvc.perform(delete("/api/houses/api-keys/{id}", "key-1").with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("revoke is forbidden for read-only members")
+    @WithHouseMember
+    void revokeForbiddenForReadOnly() throws Exception {
+        when(houseAccess.isOwner()).thenReturn(false);
+
+        mockMvc.perform(delete("/api/houses/api-keys/{id}", "key-1").with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/modules/web/src/test/java/org/reciplease/controller/ApiKeyControllerTest.java
+++ b/modules/web/src/test/java/org/reciplease/controller/ApiKeyControllerTest.java
@@ -10,6 +10,7 @@ import org.reciplease.configuration.WithHouseOwner;
 import org.reciplease.model.ApiKey;
 import org.reciplease.model.CreatedApiKey;
 import org.reciplease.model.HouseRole;
+import org.reciplease.repository.HouseRepository;
 import org.reciplease.service.ApiKeyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -44,6 +45,8 @@ class ApiKeyControllerTest {
     private ApiKeyService apiKeyService;
     @MockitoBean(name = "houseAccess")
     private HouseAccess houseAccess;
+    @MockitoBean
+    private HouseRepository houseRepository;
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- House owners can now mint a named, revocable API key scoped to one house and role (`OWNER`/`READ_ONLY`) for third-party clients that can't do an interactive sign-in — first use case is a Home Assistant integration.
- Keys are `rcpl_`-prefixed, stored only as a SHA-256 hash + short lookup prefix, and authenticate via a dedicated filter that runs ahead of the JWT resource server (`ApiKeyAuthenticationFilter` → `ApiKeyAuthenticationToken`). `HouseAccess` resolves an API key's house/role directly from the token rather than a `HouseRepository` membership lookup, since the key's assignment *is* the authorization.
- New endpoints under `/api/houses/api-keys` (owner-only): `POST` to create (returns the raw secret once), `GET` to list, `DELETE /{id}` to revoke.

## Test plan
- [x] `mvn test` passes across all modules (194 tests in core/database/web, plus the cucumber feature suite)
- [x] New unit/slice tests: `ApiKeyGeneratorTest`, `ApiKeyServiceTest`, `ApiKeyRepositoryImplTest` (embedded Mongo), `ApiKeyAuthenticationFilterTest`, `HouseAccessTest`, `CookieBearerTokenResolverTest` additions, `ApiKeyControllerTest`
- [ ] Manual: mint a key from a real house, call `/api/houses/*` endpoints with it as a bearer token