### PR TITLE
Mark ApiKeyDto.lastUsedAt / ApiKeySelfDto.houseName nullable in OpenAPI

### DIFF
--- a/modules/web/src/main/java/org/reciplease/dto/ApiKeyDto.java
+++ b/modules/web/src/main/java/org/reciplease/dto/ApiKeyDto.java
@@ -20,6 +20,8 @@ public class ApiKeyDto {
     HouseRole role;
     String keyPrefix;
     Instant createdAt;
+    // Null until the key is used for the first time.
+    @Schema(nullable = true)
     Instant lastUsedAt;
 
     public static ApiKeyDto from(final ApiKey apiKey) {

--- a/modules/web/src/main/java/org/reciplease/dto/ApiKeySelfDto.java
+++ b/modules/web/src/main/java/org/reciplease/dto/ApiKeySelfDto.java
@@ -18,6 +18,8 @@ import org.reciplease.model.HouseRole;
 @Schema(name = "ApiKeySelf")
 public class ApiKeySelfDto {
     String houseId;
+    // Null if the key's house has since been deleted but the key itself wasn't cleaned up.
+    @Schema(nullable = true)
     String houseName;
     HouseRole role;
 }


### PR DESCRIPTION
## Summary
- \`@Schema(nullable = true)\` on the two fields that can genuinely be null, mirroring the existing \`HouseMemberDto.handle\` convention — springdoc can't infer nullability from a Java type alone, and without this the generated OpenAPI type silently lies (the frontend had to work around it with a hand-rolled type intersection).
- No behavior change — annotation only affects the generated spec, not JSON serialization.

## Test plan
- [x] \`mvn test\` for the affected modules (16 API-key-related tests + OpenApiSpecExportTest)